### PR TITLE
fix(blog): フラットな.html URLに変更（本番403の修正）

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -19,15 +19,15 @@ date: 2026-07-13
 3. ビルドして生成物を確認:
 
 ```bash
-python3 blog/build.py      # public/blog/ と public/sitemap.xml が更新される
-python3 .claude/preview_server.py &   # http://127.0.0.1:8123/blog/ で確認
+python3 blog/build.py      # public/blog/*.html, public/blog.html, public/sitemap.xml を更新
+python3 .claude/preview_server.py &   # 一覧: http://127.0.0.1:8123/blog.html / 記事: /blog/<slug>.html
 ```
 
 4. **生成物ごと**コミットしてPRを出す（master直pushは保護で不可）:
 
 ```bash
 git checkout -b post/記事名
-git add articles/ public/blog/ public/sitemap.xml
+git add articles/ public/blog/ public/blog.html public/sitemap.xml
 git commit -m "post: 記事タイトル"
 git push origin HEAD
 gh pr create --fill
@@ -38,11 +38,12 @@ gh pr create --fill
 ## 仕組み
 
 - `blog/template.html` … 全記事共通の見た目（GA・OGP・ツールへの導線込み）
-- `blog/build.py` … articles/*.md → public/blog/ を生成。sitemap.xml も作る
+- `blog/build.py` … articles/*.md → `public/blog/<slug>.html`（記事）と `public/blog.html`（一覧）と sitemap.xml を生成
+- **URLはフラットな .html**（例 `/blog/kif-guide.html`）。このサイトのCloudFrontはサブディレクトリの index.html を自動配信しないため、`/blog/slug/` 形式は403になる。ディレクトリ形式にしたい場合はCloudFront Functionでの書き換えが別途必要
 - 生成物をコミットする方式なので、CI にビルド環境は不要（今の deploy がそのまま動く）
 
 ## 書くときの注意
 
-- 記事内から本体ツールへは `/`、他記事へは `/blog/slug/` で内部リンク
+- 記事内から本体ツールへは `/`、他記事へは `/blog/<slug>.html` で内部リンク
 - 画像を使う場合は `public/img/blog/` に置いて `/img/blog/ファイル名` で参照
 - AdSense 審査に通ったら `blog/template.html` の `<!-- AdSense -->` コメント部分にコードを貼って全記事を再ビルド

--- a/blog/build.py
+++ b/blog/build.py
@@ -58,6 +58,7 @@ def render(template, meta, content_html):
     out = template
     for k in ("title", "description", "slug", "date"):
         out = out.replace("{{" + k + "}}", html.escape(meta[k]) if k != "date" else meta[k])
+    out = out.replace("{{canonical}}", f"{SITE}/blog/{meta['slug']}.html")
     return out.replace("{{content}}", content_html)
 
 
@@ -74,19 +75,21 @@ def main():
             meta, body = parse_front_matter(f.read(), path)
         content = markdown.markdown(body, extensions=["extra", "sane_lists"])
         page = render(template, meta, content)
-        out_dir = os.path.join(OUT_DIR, meta["slug"])
-        os.makedirs(out_dir, exist_ok=True)
-        with open(os.path.join(out_dir, "index.html"), "w", encoding="utf-8") as f:
+        # このサイトのCloudFront構成はサブディレクトリのindex自動配信をしない
+        # (ルートのDefaultRootObjectのみ)。既存(faq.html等)と同じフラットな
+        # .html ファイルで出す。記事URLは /blog/<slug>.html
+        os.makedirs(OUT_DIR, exist_ok=True)
+        with open(os.path.join(OUT_DIR, meta["slug"] + ".html"), "w", encoding="utf-8") as f:
             f.write(page)
         articles.append(meta)
-        print(f"  built: /blog/{meta['slug']}/  ({meta['title']})")
+        print(f"  built: /blog/{meta['slug']}.html  ({meta['title']})")
 
     # 新しい日付順に並べる
     articles.sort(key=lambda a: a["date"], reverse=True)
 
-    # 記事一覧ページ
+    # 記事一覧ページ（/blog.html）
     items = "\n".join(
-        f'      <li><a href="/blog/{a["slug"]}/">{html.escape(a["title"])}</a>'
+        f'      <li><a href="/blog/{a["slug"]}.html">{html.escape(a["title"])}</a>'
         f'<span class="d">{a["date"]}</span></li>'
         for a in articles
     )
@@ -95,6 +98,7 @@ def main():
         .replace("{{title}}", "記事一覧")
         .replace("{{description}}", "将棋の棋譜・KIF形式・盤面認識に関する解説記事")
         .replace("{{slug}}", "")
+        .replace("{{canonical}}", f"{SITE}/blog.html")
         .replace("{{date}}", "")
         .replace(
             "{{content}}",
@@ -104,12 +108,12 @@ def main():
             f'    <ul class="post-list">\n{items}\n    </ul>',
         )
     )
-    with open(os.path.join(OUT_DIR, "index.html"), "w", encoding="utf-8") as f:
+    with open(os.path.join(ROOT, "public", "blog.html"), "w", encoding="utf-8") as f:
         f.write(index_html)
-    print("  built: /blog/  (一覧)")
+    print("  built: /blog.html  (一覧)")
 
     # sitemap.xml（トップ・ブログ一覧・各記事）
-    urls = [f"{SITE}/", f"{SITE}/blog/"] + [f"{SITE}/blog/{a['slug']}/" for a in articles]
+    urls = [f"{SITE}/", f"{SITE}/blog.html"] + [f"{SITE}/blog/{a['slug']}.html" for a in articles]
     body = "\n".join(f"  <url><loc>{u}</loc></url>" for u in urls)
     sitemap = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'

--- a/blog/template.html
+++ b/blog/template.html
@@ -16,11 +16,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{title}} | Shogiban to Kif ブログ</title>
   <meta name="description" content="{{description}}">
-  <link rel="canonical" href="https://shogi.nkkuma.tokyo/blog/{{slug}}/">
+  <link rel="canonical" href="{{canonical}}">
 
   <meta property="og:title" content="{{title}}">
   <meta property="og:description" content="{{description}}">
-  <meta property="og:url" content="https://shogi.nkkuma.tokyo/blog/{{slug}}/">
+  <meta property="og:url" content="{{canonical}}">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="将棋盤認識サイト">
   <meta property="og:image" content="https://shogi.nkkuma.tokyo/ogp.png">
@@ -95,7 +95,7 @@
 <body>
   <header class="site-head">
     <a href="/"><img src="/img/SHOGIWEB_TITLE.png" alt="Shogiban to Kif"></a>
-    <a class="blog-name" href="/blog/">ブログ</a>
+    <a class="blog-name" href="/blog.html">ブログ</a>
   </header>
 
   <main>
@@ -113,7 +113,7 @@
   </main>
 
   <footer class="site-foot">
-    <a href="/">Shogiban to Kif</a> ｜ <a href="/blog/">ブログ一覧</a> ｜ <a href="/privacy.html">プライバシーポリシー・利用規約</a><br>
+    <a href="/">Shogiban to Kif</a> ｜ <a href="/blog.html">ブログ一覧</a> ｜ <a href="/privacy.html">プライバシーポリシー・利用規約</a><br>
     &copy; 2019-2026 Shogiban to Kif（えぬっくま）
   </footer>
 </body>

--- a/public/blog.html
+++ b/public/blog.html
@@ -16,11 +16,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>記事一覧 | Shogiban to Kif ブログ</title>
   <meta name="description" content="将棋の棋譜・KIF形式・盤面認識に関する解説記事">
-  <link rel="canonical" href="https://shogi.nkkuma.tokyo/blog//">
+  <link rel="canonical" href="https://shogi.nkkuma.tokyo/blog.html">
 
   <meta property="og:title" content="記事一覧">
   <meta property="og:description" content="将棋の棋譜・KIF形式・盤面認識に関する解説記事">
-  <meta property="og:url" content="https://shogi.nkkuma.tokyo/blog//">
+  <meta property="og:url" content="https://shogi.nkkuma.tokyo/blog.html">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="将棋盤認識サイト">
   <meta property="og:image" content="https://shogi.nkkuma.tokyo/ogp.png">
@@ -95,7 +95,7 @@
 <body>
   <header class="site-head">
     <a href="/"><img src="/img/SHOGIWEB_TITLE.png" alt="Shogiban to Kif"></a>
-    <a class="blog-name" href="/blog/">ブログ</a>
+    <a class="blog-name" href="/blog.html">ブログ</a>
   </header>
 
   <main>
@@ -104,7 +104,7 @@
       <div class="meta">　Shogiban to Kif 運営</div>
       <style>.post-list{list-style:none;padding:0}.post-list li{margin:0 0 14px}.post-list .d{color:#999;font-size:12.5px;margin-left:10px}</style>
     <ul class="post-list">
-      <li><a href="/blog/kif-guide/">KIFファイルとは？開き方・作り方・変換方法まとめ【将棋の棋譜形式】</a><span class="d">2026-07-13</span></li>
+      <li><a href="/blog/kif-guide.html">KIFファイルとは？開き方・作り方・変換方法まとめ【将棋の棋譜形式】</a><span class="d">2026-07-13</span></li>
     </ul>
     </article>
 
@@ -116,7 +116,7 @@
   </main>
 
   <footer class="site-foot">
-    <a href="/">Shogiban to Kif</a> ｜ <a href="/blog/">ブログ一覧</a> ｜ <a href="/privacy.html">プライバシーポリシー・利用規約</a><br>
+    <a href="/">Shogiban to Kif</a> ｜ <a href="/blog.html">ブログ一覧</a> ｜ <a href="/privacy.html">プライバシーポリシー・利用規約</a><br>
     &copy; 2019-2026 Shogiban to Kif（えぬっくま）
   </footer>
 </body>

--- a/public/blog/kif-guide.html
+++ b/public/blog/kif-guide.html
@@ -16,11 +16,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>KIFファイルとは？開き方・作り方・変換方法まとめ【将棋の棋譜形式】 | Shogiban to Kif ブログ</title>
   <meta name="description" content="将棋の棋譜ファイル「KIF形式」の中身と開き方、対応アプリ、SFEN等との違い、変換方法までまとめて解説します。">
-  <link rel="canonical" href="https://shogi.nkkuma.tokyo/blog/kif-guide/">
+  <link rel="canonical" href="https://shogi.nkkuma.tokyo/blog/kif-guide.html">
 
   <meta property="og:title" content="KIFファイルとは？開き方・作り方・変換方法まとめ【将棋の棋譜形式】">
   <meta property="og:description" content="将棋の棋譜ファイル「KIF形式」の中身と開き方、対応アプリ、SFEN等との違い、変換方法までまとめて解説します。">
-  <meta property="og:url" content="https://shogi.nkkuma.tokyo/blog/kif-guide/">
+  <meta property="og:url" content="https://shogi.nkkuma.tokyo/blog/kif-guide.html">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="将棋盤認識サイト">
   <meta property="og:image" content="https://shogi.nkkuma.tokyo/ogp.png">
@@ -95,7 +95,7 @@
 <body>
   <header class="site-head">
     <a href="/"><img src="/img/SHOGIWEB_TITLE.png" alt="Shogiban to Kif"></a>
-    <a class="blog-name" href="/blog/">ブログ</a>
+    <a class="blog-name" href="/blog.html">ブログ</a>
   </header>
 
   <main>
@@ -204,7 +204,7 @@
   </main>
 
   <footer class="site-foot">
-    <a href="/">Shogiban to Kif</a> ｜ <a href="/blog/">ブログ一覧</a> ｜ <a href="/privacy.html">プライバシーポリシー・利用規約</a><br>
+    <a href="/">Shogiban to Kif</a> ｜ <a href="/blog.html">ブログ一覧</a> ｜ <a href="/privacy.html">プライバシーポリシー・利用規約</a><br>
     &copy; 2019-2026 Shogiban to Kif（えぬっくま）
   </footer>
 </body>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://shogi.nkkuma.tokyo/</loc></url>
-  <url><loc>https://shogi.nkkuma.tokyo/blog/</loc></url>
-  <url><loc>https://shogi.nkkuma.tokyo/blog/kif-guide/</loc></url>
+  <url><loc>https://shogi.nkkuma.tokyo/blog.html</loc></url>
+  <url><loc>https://shogi.nkkuma.tokyo/blog/kif-guide.html</loc></url>
 </urlset>


### PR DESCRIPTION
## 問題
マージ後、本番で `/blog/kif-guide/` と `/blog/` が **403** になった。
`/blog/kif-guide/index.html`（明示）は200・`/sitemap.xml`も200なので、原因は
**このCloudFront構成がサブディレクトリの index.html を自動配信しない**こと
（`DefaultRootObject` はルートの `/` にしか効かない）。既存サイトが全部フラットな
`.html`（faq.html等）なのはこのため。

## 対応
記事URLを既存方式に合わせてフラットな `.html` に変更（CloudFront無変更でリスクゼロ）。
- 記事: `/blog/kif-guide.html`（`public/blog/<slug>.html`）
- 一覧: `/blog.html`（`public/blog.html`）
- canonical/og:url を `{{canonical}}` に一本化、sitemap・テンプレ導線・READMEを更新
- 旧ディレクトリ生成物を削除

まだ検索インデックスされていない段階のURL変更なのでSEO損失なし。

## 確認
ローカルで `/blog.html`・`/blog/kif-guide.html`・`/sitemap.xml` すべて200、
一覧→記事リンク・参考リンク・CTAの整合を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)