### PR TITLE
alpha: 新API仕様対応（mochi_crop / mochi_ocr 追加、推奨値をデフォルトに）

### DIFF
--- a/public/alpha.html
+++ b/public/alpha.html
@@ -92,12 +92,12 @@
         <button type="button" class="btn btn-ghost" id="btn-howto">❓ はじめての方へ：使い方をみる</button>
       </div>
 
-      <!-- α: 駒認識モデル v1/v2/v3 切替（デフォルトv3。モデル詳細は非公開） -->
+      <!-- α: 駒認識モデル v1/v2/v3 切替（デフォルトv2＝推奨。モデル詳細は非公開） -->
       <div class="card-label" style="margin-top:10px;">駒認識モデル</div>
       <div class="segment model-toggle" role="group" aria-label="駒認識モデル">
         <button type="button" class="seg-btn" data-model="v1">v1</button>
-        <button type="button" class="seg-btn" data-model="v2">v2</button>
-        <button type="button" class="seg-btn active" data-model="v3">v3</button>
+        <button type="button" class="seg-btn active" data-model="v2">v2</button>
+        <button type="button" class="seg-btn" data-model="v3">v3</button>
       </div>
 
       <!-- α: 枠検出 v1/v2 切替（デフォルトv2＝新エンジン） -->
@@ -107,10 +107,23 @@
         <button type="button" class="seg-btn active" data-waku="v2">v2（新）</button>
       </div>
 
-      <!-- α: 持ち駒補正（mochi_postproc・実験的） -->
+      <!-- α: 持ち駒認識エンジン v1/v2 切替（デフォルトv2＝新エンジン・盤周囲タイル検出） -->
+      <div class="card-label" style="margin-top:10px;">持ち駒認識エンジン</div>
+      <div class="segment mochi-crop-toggle" role="group" aria-label="持ち駒認識エンジン">
+        <button type="button" class="seg-btn" data-mochi-crop="v1">v1（旧）</button>
+        <button type="button" class="seg-btn active" data-mochi-crop="v2">v2（新）</button>
+      </div>
+
+      <!-- α: 持ち駒OCR（mochi_ocr・アプリ画面の「歩 6」等の個数表示を読む） -->
       <label class="mochi-postproc-row">
-        <input type="checkbox" id="mochi-postproc" checked>
-        <span>持ち駒を補正する<small>（実験中・精度改善中）</small></span>
+        <input type="checkbox" id="mochi-ocr" checked>
+        <span>持ち駒の個数をOCRで読む<small>（アプリ画面のスクショ向け）</small></span>
+      </label>
+
+      <!-- α: 持ち駒補正（mochi_postproc・実験的。実物写真では既定OFF推奨） -->
+      <label class="mochi-postproc-row">
+        <input type="checkbox" id="mochi-postproc">
+        <span>持ち駒を駒数保存則で補正する<small>（実験的・実物写真では非推奨）</small></span>
       </label>
 
       <!-- 3. 操作列（empty / photo） -->

--- a/public/js/site-alpha.js
+++ b/public/js/site-alpha.js
@@ -157,9 +157,11 @@
     blob: null,          // 圧縮後Blob
     selectedPos: null,   // 編集中のマス "<筋><段>"
     points: null,        // α: 検出した盤枠の4隅 [[x,y]×4]（アップロード画像のピクセル座標）
-    wakuVersion: 'v2',   // α: 枠検出のバージョン切替（v1=旧UNet / v2=新エンジン）
-    modelVersion: 'v3',  // α: 駒認識モデル切替（v1=本番TF / v2=TF+後処理 / v3=新v4）
-    mochiPostproc: true  // α: 持ち駒を駒数保存則で補正（実験的・既定ON）
+    wakuVersion: 'v2',      // α: 枠検出のバージョン切替（v1=旧UNet / v2=新エンジン）
+    modelVersion: 'v2',     // α: 駒認識モデル切替（v1/v2/v3。API推奨はv2）
+    mochiCropVersion: 'v2', // α: 持ち駒認識エンジン（v1=旧 / v2=新・盤周囲タイル検出。API推奨はv2）
+    mochiOcr: true,         // α: 持ち駒の個数数字OCR（アプリ画面向け。API推奨は1）
+    mochiPostproc: false    // α: 持ち駒を駒数保存則で補正（実験的・実物写真では既定OFF推奨）
   };
 
   var els = {};
@@ -550,8 +552,10 @@
     fd.append('hidden_rotate', '0');
     fd.append('hidden_sengo', '0');       // API仕様更新: 手番は0固定(先手基準)
     fd.append('mode', 'all');             // API仕様更新: mode 必須
-    fd.append('model', state.modelVersion); // v1/v2/v3 の駒認識モデル切替
+    fd.append('model', state.modelVersion); // v1/v2/v3 の駒認識モデル切替(API推奨v2)
     fd.append('waku', state.wakuVersion);   // 枠検出 v1/v2
+    fd.append('mochi_crop', state.mochiCropVersion); // 持ち駒認識エンジン v1/v2(API推奨v2)
+    fd.append('mochi_ocr', state.mochiOcr ? '1' : '0'); // 持ち駒個数OCR(API推奨1)
     fd.append('mochi_postproc', state.mochiPostproc ? '1' : '0'); // 持ち駒の駒数保存則補正(実験的)
     return fd;
   }
@@ -673,6 +677,27 @@
           btn.classList.add('active');
         });
       })(modelBtns[m]);
+    }
+
+    // α: 持ち駒認識エンジン v1/v2 トグル
+    var mochiCropBtns = document.querySelectorAll('.mochi-crop-toggle .seg-btn');
+    for (var mc = 0; mc < mochiCropBtns.length; mc++) {
+      (function (btn) {
+        btn.addEventListener('click', function () {
+          state.mochiCropVersion = btn.getAttribute('data-mochi-crop');
+          for (var k = 0; k < mochiCropBtns.length; k++) { mochiCropBtns[k].classList.remove('active'); }
+          btn.classList.add('active');
+        });
+      })(mochiCropBtns[mc]);
+    }
+
+    // α: 持ち駒OCR（mochi_ocr）チェックボックス
+    var mochiOcrChk = $('mochi-ocr');
+    if (mochiOcrChk) {
+      mochiOcrChk.checked = state.mochiOcr;
+      mochiOcrChk.addEventListener('change', function () {
+        state.mochiOcr = mochiOcrChk.checked;
+      });
     }
 
     // α: 持ち駒補正（mochi_postproc）チェックボックス


### PR DESCRIPTION
alphaの認識APIに新しいパラメータが追加されたので対応しました。

## 新パラメータ表との対応
| フィールド | 対応 |
|---|---|
| `mochi_crop` (v1/v2) | 新規追加。トグルUI「持ち駒認識エンジン」を追加、既定を推奨のv2に |
| `mochi_ocr` (0/1) | 新規追加。チェックボックス「持ち駒の個数をOCRで読む」を追加、既定を推奨の1(ON)に |
| `model` (v1/v2/v3) | 既定をv3→**v2**（API推奨）に変更 |
| `mochi_postproc` (0/1) | 既定をON→**OFF**に変更（仕様書に「実物写真主体なら0推奨」とあるため） |
| `waku` (v1/v2) | 変更なし（既定v2のまま。今回のパラメータ表に強い既定変更の指示なし） |
| `upfile` / `hidden_rotate` / `hidden_sengo` / `mode` | 変更なし（既に対応済み） |

初期状態が推奨の組み合わせ（`model=v2` & `mochi_crop=v2` & `mochi_ocr=1`）になるようにしています。

## 確認
ローカルプレビューで `alpha.html` を開き、
- 3つのトグル（モデル/枠検出/持ち駒認識エンジン）が意図した既定値でハイライトされている
- 持ち駒OCRがON、駒数保存則補正がOFFになっている
- トグルのクリックでちゃんと状態が切り替わる
- コンソールエラーなし

をスクリーンショット付きで確認済みです（実際の認識APIへの疎通は本番キーが必要なため未実施）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)