### PR TITLE
fix: シェアボタンの表記を実挙動に合わせる（𝕏限定→汎用シェア）

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,7 @@
         <button type="button" class="btn btn-primary" onclick="save_text()"><i class="fa fa-save" aria-hidden="true"></i></button>
         <!-- 局面画像（js/kyokumen.js）: このブロック内に置くことで既存の表示切替に相乗りする -->
         <div class="text-muted" style="margin-top:8px;">局面画像</div>
-        <button type="button" class="btn btn-dark" style="background:#000;color:#fff;" onclick="Kyokumen.share(window.result_json)">𝕏 画像でポスト</button>
+        <button type="button" class="btn btn-dark" style="background:#000;color:#fff;" onclick="Kyokumen.share(window.result_json)">📤 画像でシェア</button>
         <button type="button" class="btn btn-primary" onclick="Kyokumen.save(window.result_json)"><i class="fa fa-picture-o" aria-hidden="true"></i> 保存</button>
       </div>
       <div id="guruguru" class="loader" style="display: none">Loading...</div>

--- a/public/modern.html
+++ b/public/modern.html
@@ -125,7 +125,7 @@
 
             <div class="output-label">局面画像</div>
             <div class="copy-row">
-              <button type="button" class="btn" id="btn-img-share">𝕏 画像でポスト</button>
+              <button type="button" class="btn" id="btn-img-share">📤 画像でシェア</button>
               <button type="button" class="btn" id="btn-img-save">画像を保存</button>
             </div>
           </div>


### PR DESCRIPTION
実機確認で判明した通り、スマホの共有はOSの共有シート（X/LINE/Discord/AirDrop等から選択）なので、「𝕏 画像でポスト」という表記を「📤 画像でシェア」に変更。

- LINEグループ（教室・クラブ・大会運営の主要連絡網）に局面画像が流れるのはむしろ拡散経路として有利
- 透かしは画像自体に入っているのでどこに共有されてもツールの導線になる
- PCのフォールバック（X intent直行）・トースト文言は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)