### PR TITLE
fix: alpha APIを新エンドポイントへ切替（認証修正対応）

### DIFF
--- a/public/js/site-alpha.js
+++ b/public/js/site-alpha.js
@@ -5,7 +5,7 @@
   'use strict';
 
   // ===== 定数 =====
-  var API_URL = 'https://waxpodihgi.execute-api.ap-northeast-1.amazonaws.com/recognize';
+  var API_URL = 'https://scv8fb0ca0.execute-api.ap-northeast-1.amazonaws.com/alpha/recognize';
   var API_KEY = '__ALPHA_API_KEY__';
   var PIYO_SAVE_URL = 'https://us-central1-shogiban2kif.cloudfunctions.net/save_kif';
   var KENTO_URL = 'https://www.kento-shogi.com/?initpos=';


### PR DESCRIPTION
API側の認証修正に伴い、alphaページのエンドポイントを新URL（`scv8fb0ca0.execute-api.../alpha/recognize`）へ切替。

- 変更は `site-alpha.js` のAPI_URL 1行のみ。**本番API（api.nkkuma.tokyo / site.js）は触っていません**
- 新しいAPIキーはGitHub Secrets `SHOGI_ALPHA_API_KEY` に設定済み（ユーザー対応済み）とのことなので、このPRは **[skip ci]なしでマージ→GHA自動デプロイ**で反映します（ローカルの鍵ファイルは旧キーのため deploy.sh は使わない）
- マージ後、本番のalphaページで実写真の変換が通るか（=新キー+新エンドポイントの認証確認）をe2eで検証します
- 未デプロイだったrenzoku beta（PR #11）も同時に本番へ出ます（未リンク・noindexなので公開影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)