### PR TITLE
プライバシーポリシーに動画アップロード機能の節を追加

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -32,7 +32,7 @@
 <body>
   <header>
     <div class="wrap">
-      <div class="badge">最終更新：<time datetime="2025-08-23">2026/01/31</time></div>
+      <div class="badge">最終更新：<time datetime="2026-07-16">2026/07/16</time></div>
       <h1 class="title">プライバシーポリシー・利用規約（統合）</h1>
       <div class="sub">本ページは、将棋盤認識サイトおよび提供するAPIサービス（以下「本サービス」）におけるデータの取扱いおよび利用条件を定めるものです。ご利用により本内容に同意いただいたものとみなします。</div>
     </div>
@@ -44,6 +44,7 @@
       <strong>目次</strong>
       <div class="toc small">
         <a href="#collect">1. 収集する情報</a>
+        <a href="#video">1-2. 動画アップロード機能（β）</a>
         <a href="#purpose">2. 情報の利用目的</a>
         <a href="#retention">3. 保存期間・削除</a>
         <a href="#third">4. 第三者提供・外部送信</a>
@@ -74,6 +75,17 @@
         </li>
       </ul>
       <p class="small muted">※本ページ（privacy.html）は静的ページであり、広告配信や流入調査スクリプトは読み込みません。Analytics はメインページ等(API除く)でのみ利用します。</p>
+    </section>
+
+    <section id="video" class="card">
+      <h2>1-2. 動画アップロード機能（β）における取扱い</h2>
+      <ul>
+        <li><strong>収集する情報</strong>：対局動画から抽出した盤面画像（キーフレーム）、音声を除去した映像、生成された棋譜データ</li>
+        <li><strong>音声の取扱い</strong>：アップロードされた動画の音声は、棋譜化処理の完了後すみやかに削除します。音声を解析・保存・利用することはありません（処理に失敗した場合も30日以内に自動削除されます）。</li>
+        <li>映像・画像・棋譜は、認識精度向上およびモデル学習のため保存します（アップロード画像と同様の取扱い）。</li>
+        <li>対局相手など第三者が映る動画をアップロードする場合は、必要な同意を得た上でご利用ください。</li>
+        <li><a href="#contact">お問い合わせ</a>より、保存された映像・画像の削除を依頼できます。</li>
+      </ul>
     </section>
 
     <section id="purpose" class="card">

--- a/public/video.html
+++ b/public/video.html
@@ -61,7 +61,7 @@
       <button class="btn" id="btn-start" disabled>変換スタート</button>
     </div>
     <div id="file-info"></div>
-    <p class="note">対応: mp4 / mov、目安2GBまで。動画は処理後30日で自動削除されます。</p>
+    <p class="note">対応: mp4 / mov、目安2GBまで。音声は処理後すみやかに削除されます。映像と棋譜は認識精度向上・学習のため保存されます（詳細：<a href="privacy.html">プライバシーポリシー</a>）。対局相手など他の方が映る場合は同意を得てご利用ください。アップロードをもって上記に同意したものとみなします。</p>
   </section>
 
   <!-- STEP 2: アップロード + 変換中 -->


### PR DESCRIPTION
動画機能のデータ取扱い実態(aws-nkkuma PR#8: 音声即削除・映像/フレーム/棋譜は学習用長期保存)に合わせたポリシー整備。文言はオーナーレビュー・承認済み(2026-07-16)。ローカルで両ページの描画確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)