### PR TITLE
トップページのフッターに動画まるごと棋譜化(β)への導線を追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -146,7 +146,15 @@
         <a href="/privacy.html" target="_blank">プライバシーポリシー・利用規約</a>
         に同意したものとみなされます。</font>
       </p>
-      
+
+      <!-- 動画まるごと棋譜化(β)への導線。イベント案内動画に映る上部の操作フローには
+           影響しないよう、フッター領域にのみ追加している -->
+      <div style="margin:14px auto; max-width:420px; border:1px solid #d8d3c8; border-radius:10px;
+                  padding:10px 14px; font-size:14px; background:#fffdf8; text-align:center;">
+        🎬 <b>新機能（β版）</b>：対局を動画で撮っておくだけで棋譜に<br>
+        <a href="/video.html">動画まるごと棋譜化 を試してみる →</a>
+      </div>
+
       <br>開発：nkkuma　twitter始めました<br>
       <a href="https://twitter.com/nkkuma_service?ref_src=twsrc%5Etfw"
       class="twitter-follow-button" data-show-count="false">


### PR DESCRIPTION
イベント案内動画(現行UIの手順を撮影したもの)への影響を避けるため、フッター領域限定の追加。上部操作フローのID・レイアウト・JSは無変更(ブラウザで検証済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)