### PR TITLE
動画選択時に2GB上限の事前チェックを追加

### DIFF
--- a/public/video.html
+++ b/public/video.html
@@ -591,8 +591,22 @@
   }
 
   // ---- UI ----
+  // 変換まで通る実質上限。アップロードAPI自体は約3.9GiBまで受けるが、
+  // 抽出処理の作業領域(4GiB)が元動画+音声除去コピーで約2倍を要するため、
+  // それ以上は数分待たせた末に失敗する。門前で分かるようにここで止める。
+  var MAX_UPLOAD_BYTES = 2 * 1000 * 1000 * 1000;
   $('file-input').addEventListener('change', function (e) {
-    state.file = e.target.files[0] || null;
+    var f = e.target.files[0] || null;
+    if (f && f.size > MAX_UPLOAD_BYTES) {
+      state.file = null;
+      $('btn-start').disabled = true;
+      $('file-info').textContent = f.name + '（' + fmtSize(f.size) + '）は上限の2GBを超えています。'
+        + 'カメラの設定を 720p / 30fps にして撮り直すか、動画を前半・後半に分けてお試しください。'
+        + '（1080pの高画質設定では約30分で2GBに達します）';
+      e.target.value = '';
+      return;
+    }
+    state.file = f;
     $('btn-start').disabled = !state.file;
     $('file-info').textContent = state.file
       ? state.file.name + '（' + fmtSize(state.file.size) + '）'


### PR DESCRIPTION
## 背景
行橋支部の金丸さんがアクションカメラ映像で変換を試したが、S3にも Step Functions にも到達の痕跡がない=アップロード段階で失敗していた。アクションカメラの高ビットレート映像(30分で10GB超)が上限に当たった可能性が濃厚。現状はHTTPエラー文言のみで、サイズが原因だと本人に伝わらない。

## 変更
- ファイル選択時に 2GB 超を検知して即座に案内を表示(ボタン無効化・選択クリア)
- 案内には回避策を明記: **720p/30fpsでの撮影** or 前後半への分割、1080p高画質は約30分で2GBに達する旨
- 閾値2GBの根拠: アップロードAPI自体は約3.9GiBまで通るが、extract Lambda の /tmp(4GiB)が元動画+音声除去コピーで約2倍を消費するため、実質上限は約2GB。「目安2GBまで」という既存文言とも一致

## 検証
ローカルHTTP配信でブラウザ実機確認:
- 3.2GB(size偽装File)→ 拒否・案内表示・スタート無効・input クリア
- 558MB → 通常受理

8/2の行橋大会でモニター運用(アクションカメラ2台)が予定されており、当日この事故を繰り返さないための事前対策。

🤖 Generated with [Claude Code](https://claude.com/claude-code)