### PR TITLE
video: iOS案内の表示崩れ修正(ボタン内→ⓘ折りたたみ)

### DIFF
--- a/public/video.html
+++ b/public/video.html
@@ -112,12 +112,15 @@
       <label class="btn btn-primary">
         動画を選ぶ
         <input type="file" id="file-input" accept="video/mp4,video/quicktime" hidden>
-        <p style="font-size:12px;color:#888;margin:6px 0 0;">iPhoneでは動画を選んだあと、iOS側の準備(iCloudからの取得・形式変換)で数分かかることがあります。画面はそのままお待ちください。</p>
       </label>
       <button class="btn" id="btn-start" disabled>変換スタート</button>
       <button class="btn" id="btn-sample">サンプル動画で試す</button>
     </div>
     <div id="file-info"></div>
+    <details style="font-size:12px;color:#888;margin-top:6px;">
+      <summary style="cursor:pointer;">ⓘ スマホからアップロードする方へ</summary>
+      <p style="margin:6px 0 0;">iPhoneでは動画を選んだあと、iOS側の準備（iCloudからの取得・形式変換）で数分かかることがあります。画面はそのままお待ちください。PCからのアップロードのほうがスムーズです。</p>
+    </details>
     <p class="note">対応: mp4 / mov、目安2GBまで。音声は処理後すみやかに削除されます。映像と棋譜は認識精度向上・学習のため保存されます（詳細：<a href="privacy.html">プライバシーポリシー</a>）。対局相手など他の方が映る場合は同意を得てご利用ください。アップロードをもって上記に同意したものとみなします。</p>
   </section>
 


### PR DESCRIPTION
案内文がボタン内部に入り警告バナー状に見えていた表示崩れの修正。モバイル実機プレビューで確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)