### PR TITLE
video: 訂正UI一式をβ昇格(α検証済みの全機能を video.html へ)

### DIFF
--- a/public/video.html
+++ b/public/video.html
@@ -92,6 +92,70 @@
     #move-list li { padding: 4px 10px; border-bottom: 1px solid #f2f2f2; cursor: pointer; }
     #move-list li.active { background: #fdecec; }
     #move-list li.warn { color: #b26a00; }
+    /* 訂正モード（間違った手の指し直し） */
+    #board.correcting .sq { cursor: pointer; }
+    #board .sq.sel { outline: 2px solid #c62828; outline-offset: -2px; background: #fbd2ce; }
+    .hands .hand-piece { display: inline-block; padding: 0 4px; margin-left: 3px; }
+    .hands.tappable .hand-piece { cursor: pointer; border: 1px solid #d8d3c8;
+                                  border-radius: 4px; background: #fff; }
+    .hands .hand-piece.sel { background: #fbd2ce; border-color: #c62828; }
+    #correct-bar { background: #eef4fb; border: 1px solid #c8d9ec; border-radius: 8px;
+                   padding: 8px 10px; margin: 0 auto 8px; max-width: 342px; font-size: 13px; }
+    #correct-bar.busy { background: #f6f4ef; border-color: #ddd; color: #666; }
+    /* 再解析中の生存表示（点滅ドット + 経過秒はJSで更新） */
+    #correct-bar .busy-dot { display: none; }
+    #correct-bar.busy .busy-dot { display: inline-block; width: 8px; height: 8px;
+                   border-radius: 50%; background: #c62828; margin-right: 6px;
+                   animation: correct-pulse 1s ease-in-out infinite; }
+    @keyframes correct-pulse { 0%, 100% { opacity: .25; transform: scale(.8); }
+                               50% { opacity: 1; transform: scale(1.1); } }
+    /* 訂正で変わった手のハイライト（数秒で消す） */
+    #move-list li.changed { background: #fff3c4; }
+    /* 訂正モード中は盤タップとキャンセル以外を封じる（誤操作で訂正が飛ぶのを防ぐ） */
+    .locked { pointer-events: none; opacity: .45; }
+    /* 実映像パネル(常設): 盤の下に、その手の時刻の実映像を盤領域だけ切り出して表示 */
+    #photo-panel { max-width: 342px; margin: 6px auto 2px; }
+    #photo-crop { position: relative; overflow: hidden; width: 100%;
+                  border-radius: 6px; border: 1px solid #d8d3c8; background: #1c1c1c; }
+    #photo-crop img { position: absolute; display: block; }
+    #photo-panel .photo-nav { display: flex; align-items: center; justify-content: space-between;
+                              gap: 4px; margin-top: 4px; font-size: 12px; color: #666; }
+    /* 再解析中の盤オーバーレイ: 白半透明+スピナーで「今は触れない」を明示 */
+    #board { position: relative; }
+    .board-overlay { position: absolute; inset: 0; z-index: 5;
+                     background: rgba(255,255,255,.68);
+                     display: flex; flex-direction: column; align-items: center;
+                     justify-content: center; gap: 10px; font-size: 13px; color: #555; }
+    .board-overlay .spin { width: 30px; height: 30px; border: 3px solid #c62828;
+                           border-top-color: transparent; border-radius: 50%;
+                           animation: board-spin .9s linear infinite; }
+    @keyframes board-spin { to { transform: rotate(360deg); } }
+    /* PCレイアウト(900px以上): 盤と実映像を左右に並べ、常時比較しやすくする。
+       スマホ(既定)は従来どおり縦積み */
+    @media (min-width: 900px) {
+      main { max-width: 880px; }
+      main > .card { max-width: 560px; margin-left: auto; margin-right: auto; }
+      main > .card.only-3 { max-width: 850px; }
+      /* :not([hidden]) ガード必須: id指定のdisplayはUAの [hidden]{display:none} に勝って
+         しまうため、素の #viewer{display:grid} だと結果表示前に空のグリッドが見える */
+      #viewer:not([hidden]) { display: grid; grid-template-columns: 380px 380px;
+                justify-content: center; column-gap: 30px; align-items: start; }
+      #correct-bar, #correct-done { grid-row: 1; grid-column: 1 / -1;
+                                    max-width: 790px; width: 100%; justify-self: center; }
+      #hands-gote  { grid-row: 2; grid-column: 1; max-width: 380px; }
+      /* width明示が必要: グリッドアイテムで margin:auto が付くと fit-content 幅に
+         縮んでしまう(文字幅ベースの236px程度になる実測) */
+      #board       { grid-row: 3; grid-column: 1; width: 380px; max-width: 380px; }
+      #board .sq   { font-size: 24px; }
+      #hands-sente { grid-row: 4; grid-column: 1; max-width: 380px; }
+      #viewer .nav-row { grid-row: 5; grid-column: 1; }
+      #correct-entry   { grid-row: 6; grid-column: 1; }
+      #photo-panel { grid-row: 2 / span 3; grid-column: 2; max-width: 380px; width: 100%; }
+      #move-list   { grid-row: 5 / span 2; grid-column: 2; max-width: 380px; width: 100%;
+                     max-height: 230px; margin: 10px 0 6px; }
+      #eval-wrap   { grid-row: 7; grid-column: 1 / -1; }
+      #tools-row   { grid-row: 8; grid-column: 1 / -1; justify-content: center; }
+    }
   </style>
 </head>
 <body data-step="1">
@@ -99,6 +163,7 @@
   <h1>動画まるごと棋譜化 <span class="beta">β版</span></h1>
   <p class="lead">対局を撮った動画1本から、指し手つきの棋譜（KIF）を自動で復元します。
     盤全体が映る位置にスマホを固定して撮影した動画をお使いください。</p>
+
 
   <!-- STEP 1: 動画選択 -->
   <section class="card only-1">
@@ -126,6 +191,10 @@
       <button class="btn" id="btn-sample">サンプル動画で試す</button>
     </div>
     <div id="file-info"></div>
+    <label style="display:flex;align-items:center;gap:6px;font-size:12.5px;color:#666;margin-top:8px;cursor:pointer">
+      <input type="checkbox" id="compress-toggle" checked style="width:16px;height:16px;flex:none">
+      アップロード前にブラウザで圧縮する（推奨。PCの動作が重くなる場合はオフ）
+    </label>
     <details style="font-size:12px;color:#888;margin-top:6px;">
       <summary style="cursor:pointer;">ⓘ スマホからアップロードする方へ</summary>
       <p style="margin:6px 0 0;">iPhoneでは動画を選んだあと、iOS側の準備（iCloudからの取得・形式変換）で数分かかることがあります。画面はそのままお待ちください。PCからのアップロードのほうがスムーズです。</p>
@@ -179,9 +248,28 @@
 
     <!-- 対局再現ビューワー -->
     <div id="viewer" hidden>
+      <!-- 訂正モードの案内バー（訂正中のみ表示） -->
+      <div id="correct-bar" hidden>
+        <span class="busy-dot" aria-hidden="true"></span><span id="correct-msg"></span>
+        <div class="row" style="margin-top:6px">
+          <button class="btn btn-sm" id="btn-correct-cancel">訂正をやめる</button>
+        </div>
+      </div>
+      <div id="correct-done" style="background:#f0f8f1;border:1px solid #cfe3d2;border-radius:8px;
+           padding:8px 10px;margin:0 auto 8px;max-width:342px;font-size:13px" hidden></div>
       <div class="hands" id="hands-gote"></div>
       <div id="board"></div>
       <div class="hands" id="hands-sente"></div>
+      <!-- 実映像パネル(常設): 手を進めるたびに、その手の時刻に最も近い実映像のコマを
+           盤領域だけ切り出して表示する。復元盤面と実映像を常に突き合わせられる -->
+      <div id="photo-panel" hidden>
+        <div id="photo-crop"><img id="photo-img" alt="実際の対局映像のコマ"></div>
+        <div class="photo-nav">
+          <button class="btn btn-sm" id="photo-prev">◀ 前のコマ</button>
+          <span id="photo-caption"></span>
+          <button class="btn btn-sm" id="photo-next">次のコマ ▶</button>
+        </div>
+      </div>
       <div class="nav-row">
         <button class="btn btn-sm" id="btn-first">|◀</button>
         <button class="btn btn-sm" id="btn-prev">◀ 前へ</button>
@@ -189,13 +277,16 @@
         <button class="btn btn-sm" id="btn-next">次へ ▶</button>
         <button class="btn btn-sm" id="btn-last">▶|</button>
       </div>
+      <div class="row" id="correct-entry" style="justify-content:center;margin:0 0 4px">
+        <button class="btn btn-sm" id="btn-correct" hidden>この手が違う（訂正する）</button>
+      </div>
       <ol id="move-list"></ol>
       <div id="eval-wrap" hidden>
         <div style="font-size:12.5px;color:#888;margin:10px auto 4px;max-width:342px">形勢グラフ（上＝先手有利。点をタップでその局面へ）</div>
         <svg id="eval-graph" viewBox="0 0 342 110"
              style="width:100%;max-width:342px;display:block;margin:0 auto;background:#fcfbf8;border:1px solid #eee;border-radius:8px"></svg>
       </div>
-      <div class="row" style="margin:10px 0 14px">
+      <div class="row" id="tools-row" style="margin:10px 0 14px">
         <button class="btn btn-sm" id="btn-sfen">この局面のSFENをコピー</button>
         <a class="btn btn-sm" id="btn-kento" href="#" target="_blank" rel="noopener">KENTOで開く</a>
       </div>
@@ -249,6 +340,15 @@
 
   var state = { file: null, jobId: null };
   function $(id) { return document.getElementById(id); }
+
+  // 圧縮のオン/オフ(既定オン)。WebCodecsエンコードはCPU/GPUを占有し、同じPCで
+  // 動いている他のアプリの動作を重くすることがあるため、ユーザーが切れるようにする。
+  // オフの選択は端末(localStorage)に記憶する。
+  var COMPRESS_OFF_KEY = 'videoKifuCompressOff';
+  function compressEnabled() {
+    var el = $('compress-toggle');
+    return !el || el.checked;
+  }
 
   // ---- ジョブの記憶（ページを閉じても結果を取りに戻れるように） ----
   // アップロード完了後の変換はサーバー側で進むため、jobIdさえ覚えていれば
@@ -495,6 +595,7 @@
     var svg = $('eval-graph');
     svg.innerHTML = parts.join('');
     svg.onclick = function (ev) {
+      if (correction.active) { return; } // 訂正中は局面移動を封じる
       var t = ev.target;
       if (t && t.getAttribute && t.getAttribute('data-i') !== null) {
         showPosition(Number(t.getAttribute('data-i')));
@@ -516,6 +617,7 @@
   // evaluate完了後、局面を保ったまま形勢グラフだけ差し込む(先出し表示の後続)。
   function applyEvals(job) {
     if (!viewer.positions) { return; } // 棋譜未表示なら何もしない(通常起きない)
+    if (correction.active || correction.busy) { return; } // 訂正中に盤を再描画しない(どのみち訂正後は陳腐化する)
     var result = (job && job.result) || {};
     if (Array.isArray(result.evals) && result.evals.length >= 2) {
       viewer.evals = result.evals;
@@ -566,13 +668,24 @@
     return url;
   }
 
-  function handLineText(hand, mark) {
-    var parts = [];
+  // 持ち駒は駒ごとに span で描く（訂正モードで「打つ駒」をタップ選択できるように）
+  function renderHandLine(el, hand, mark, side) {
+    el.innerHTML = '';
+    el.appendChild(document.createTextNode(mark + '持駒：'));
+    var any = false;
     HAND_ORDER.forEach(function (k) {
       var n = hand[k] || 0;
-      if (n > 0) { parts.push(KANJI_1[k] + (n > 1 ? n : '')); }
+      if (n > 0) {
+        any = true;
+        var sp = document.createElement('span');
+        sp.className = 'hand-piece';
+        sp.setAttribute('data-kind', k);
+        sp.setAttribute('data-side', side);
+        sp.textContent = KANJI_1[k] + (n > 1 ? n : '');
+        el.appendChild(sp);
+      }
     });
-    return mark + '持駒：' + (parts.length ? parts.join(' ') : 'なし');
+    if (!any) { el.appendChild(document.createTextNode('なし')); }
   }
 
   function renderBoard(pos, lastTo) {
@@ -582,6 +695,8 @@
       for (var s = 9; s >= 1; s--) {
         var sq = document.createElement('div');
         sq.className = 'sq';
+        sq.setAttribute('data-s', s);
+        sq.setAttribute('data-d', d);
         var v = pos.ban[String(s) + String(d)];
         if (v && v !== ' * ') {
           sq.textContent = KANJI_1[v.substr(1)] || '';
@@ -591,16 +706,18 @@
         board.appendChild(sq);
       }
     }
-    $('hands-gote').textContent = handLineText(pos.hands.gote, '△');
-    $('hands-sente').textContent = handLineText(pos.hands.sente, '▲');
+    renderHandLine($('hands-gote'), pos.hands.gote, '△', 'gote');
+    renderHandLine($('hands-sente'), pos.hands.sente, '▲', 'sente');
   }
 
   function showPosition(i) {
     if (!viewer.positions) { return; }
+    if (correction.active) { exitCorrection(); } // 別の手へ移動したら訂正は仕切り直し
     viewer.idx = Math.max(0, Math.min(i, viewer.positions.length - 1));
     var pos = viewer.positions[viewer.idx];
     var lastTo = viewer.idx > 0 ? viewer.plies[viewer.idx - 1].move.to : null;
     renderBoard(pos, lastTo);
+    $('btn-correct').disabled = viewer.idx === 0;
     var ev = viewer.evals ? viewer.evals[viewer.idx] : null;
     $('ply-label').textContent =
       (viewer.idx === 0 ? '開始局面' : viewer.idx + '手目') + evalLabel(ev);
@@ -612,6 +729,7 @@
     var active = document.querySelector('#move-list li.active');
     if (active) { active.scrollIntoView({ block: 'nearest' }); }
     $('btn-kento').href = kentoGameUrl(viewer.idx);
+    updatePhotoForPly(); // 実映像パネルを現在手に追従させる
   }
 
   function initViewer(result, evalsPending) {
@@ -647,12 +765,480 @@
         li.className = 'warn';
         li.title = ply.warnings.join(' / ');
       }
-      li.addEventListener('click', function () { showPosition(i + 1); });
+      li.addEventListener('click', function () {
+        if (correction.active) { return; } // 訂正中の誤タップで訂正が飛ばないように
+        showPosition(i + 1);
+      });
       list.appendChild(li);
     });
 
+    // 訂正はv2ジョブ(イベント時刻frameIdx持ち)のみ対応。v1や古い結果ではボタンを出さない
+    viewer.correctedAt = result.correctedAt || null;
+    var canCorrect = result.pipeline === 'v2' && !!state.jobId &&
+      result.plies.length > 0 && typeof result.plies[0].frameIdx === 'number';
+    $('btn-correct').hidden = !canCorrect;
+    $('correct-done').hidden = true;
+    // 実映像パネル: v2ジョブなら着地フレーム一覧を読み込んで常時表示する
+    // (フレームはジョブ単位でキャッシュされ、訂正後の結果差し替えでは再取得しない)
+    if (canCorrect) { initPhotoPanel(); }
+    else { photo.frames = null; $('photo-panel').hidden = true; }
+
     $('viewer').hidden = false;
     showPosition(viewer.positions.length - 1); // 最終局面から
+  }
+
+  // ---- 訂正モード（間違った手の指し直し → ピンとして再解） ----
+  // 「間違っている最初の手」をユーザーが指し直すと、その手をピン(制約)として
+  // バックエンドがビームだけ再解し、以降の手も自動で直る(動画再処理なし・数秒)。
+  // それより前の手が正しい前提なので、直前局面の盤面表示は信頼できる。
+  var correction = { active: false, busy: false, ply: 0,
+                     from: null, fromKind: null, dropKind: null, timer: null };
+
+  function setCorrectMsg(txt) { $('correct-msg').textContent = txt; }
+  function correctionSide() { return viewer.plies[correction.ply - 1].side; }
+
+  // 再解の所要は対局の長さ(イベント数)にほぼ比例する。実測: 5手<1秒 / 83手約20秒
+  // (Lambda 1vCPU化後は約12秒)。嘘をつかない粗い目安を出す。
+  function correctEstimateText() {
+    var n = viewer.plies ? viewer.plies.length : 0;
+    if (n >= 60) { return '目安 10〜30秒'; }
+    if (n >= 25) { return '目安 5〜15秒'; }
+    return '目安 数秒';
+  }
+  // 再解析中の生存表示: 経過秒を毎秒更新し、30秒を超えたら文言を切り替える
+  // (30秒はAPI Gatewayの応答上限。以降はポーリング保険が結果を拾う)
+  function startCorrectTimer() {
+    stopCorrectTimer();
+    var t0 = Date.now();
+    function render() {
+      var s = Math.round((Date.now() - t0) / 1000);
+      setCorrectMsg(s >= 30
+        ? 'サーバーの応答を待っています… ' + s + '秒経過（最大60秒ほどかかることがあります）'
+        : '以降の手を再解析しています… ' + s + '秒経過（' + correctEstimateText() + '）');
+    }
+    render();
+    correction.timer = setInterval(render, 1000);
+  }
+  function stopCorrectTimer() {
+    if (correction.timer) { clearInterval(correction.timer); correction.timer = null; }
+  }
+
+  function movesEqual(a, b) {
+    return a.to[0] === b.to[0] && a.to[1] === b.to[1] && a.kind === b.kind &&
+      !!a.promote === !!b.promote &&
+      ((a.from == null) === (b.from == null)) &&
+      (a.from == null || (a.from[0] === b.from[0] && a.from[1] === b.from[1]));
+  }
+
+  // 訂正モード中は「盤タップ・持ち駒タップ・キャンセル・写真送り」以外を封じる。
+  // ナビや一覧タップで訂正が意図せず解除される事故を防ぐ(オーナー要望 2026-07-22)。
+  // 再解析中に盤へ被せる白半透明+スピナー(「今は触れない」の視覚化)。
+  // renderBoard は innerHTML を作り直すため、オーバーレイは busy の間だけ動的に足す
+  function showBoardOverlay(msg) {
+    removeBoardOverlay();
+    var ov = document.createElement('div');
+    ov.className = 'board-overlay';
+    ov.id = 'board-overlay';
+    var sp = document.createElement('div');
+    sp.className = 'spin';
+    var tx = document.createElement('span');
+    tx.textContent = msg;
+    ov.appendChild(sp);
+    ov.appendChild(tx);
+    $('board').appendChild(ov);
+  }
+  function removeBoardOverlay() {
+    var ov = document.getElementById('board-overlay');
+    if (ov && ov.parentNode) { ov.parentNode.removeChild(ov); }
+  }
+
+  function setViewerLocked(locked) {
+    ['btn-first', 'btn-prev', 'btn-next', 'btn-last', 'btn-sfen',
+     'btn-copy', 'btn-save', 'btn-retry', 'btn-correct'].forEach(function (id) {
+      var el = $(id);
+      if (el) { el.disabled = locked; }
+    });
+    var kento = $('btn-kento'); // <a>なのでdisabledが効かない
+    if (kento) {
+      kento.style.pointerEvents = locked ? 'none' : '';
+      kento.style.opacity = locked ? '.45' : '';
+    }
+    $('move-list').classList.toggle('locked', locked);
+    $('eval-wrap').classList.toggle('locked', locked);
+  }
+
+  // ---- 実映像パネル(常設) ----
+  // 検証ビューワー由来の体験: 手を進めるたびに、その手の時刻に最も近い着地静止フレーム
+  // (GET /jobs/{jobId}/frames の presigned URL)を盤の下に表示し、復元盤面と実映像を
+  // 常に突き合わせられる。盤の四隅(points)があれば盤領域だけをCSSで切り出す。
+  // API未対応・v1ジョブ(404)ならパネルごと出さない。
+  var photo = { frames: null, points: null, idx: null, imgW: 0, imgH: 0 };
+
+  function fmtTime(t) {
+    var m = Math.floor(t / 60), s = Math.round(t % 60);
+    if (s === 60) { m++; s = 0; }
+    return m + ':' + (s < 10 ? '0' : '') + s;
+  }
+  function loadFrames() {
+    if (viewer.framesJobId !== state.jobId) { // ジョブ単位でキャッシュ(訂正後の再表示で再取得しない)
+      viewer.framesJobId = state.jobId;
+      viewer.framesPromise = fetch(API_BASE + '/jobs/' + encodeURIComponent(state.jobId) + '/frames',
+        { cache: 'no-store' })
+        .then(function (res) { return res.ok ? res.json() : null; })
+        .catch(function () { return null; });
+    }
+    return viewer.framesPromise;
+  }
+  function nearestFrameIdx(t) {
+    var fs = photo.frames;
+    var best = 0;
+    for (var i = 1; i < fs.length; i++) {
+      if (Math.abs(fs[i].t - t) < Math.abs(fs[best].t - t)) { best = i; }
+    }
+    return best;
+  }
+  // いま注目している手(訂正中ならその手、通常はビューワーの現在手)の映像時刻
+  function currentPly() { return correction.active ? correction.ply : viewer.idx; }
+  function currentPlyTime() {
+    var ply = currentPly();
+    if (!viewer.plies || ply < 1) { return 0; }
+    var p = viewer.plies[ply - 1];
+    return (p && typeof p.frameIdx === 'number') ? p.frameIdx : 0;
+  }
+  // 盤の四隅のバウンディングボックス+余白10%で切り出す(CSSのみ。points無しなら全体表示)
+  function applyPhotoCrop() {
+    var img = $('photo-img');
+    var crop = $('photo-crop');
+    if (img.naturalWidth) { photo.imgW = img.naturalWidth; photo.imgH = img.naturalHeight; }
+    var pts = photo.points;
+    if (!pts || !photo.imgW) {
+      crop.style.paddingTop = '';
+      img.style.cssText = 'position:static;width:100%;height:auto;display:block';
+      return;
+    }
+    var xs = pts.map(function (p) { return p[0]; });
+    var ys = pts.map(function (p) { return p[1]; });
+    var mx = (Math.max.apply(null, xs) - Math.min.apply(null, xs)) * 0.10;
+    var my = (Math.max.apply(null, ys) - Math.min.apply(null, ys)) * 0.10;
+    var x0 = Math.max(0, Math.min.apply(null, xs) - mx);
+    var y0 = Math.max(0, Math.min.apply(null, ys) - my);
+    var x1 = Math.min(photo.imgW, Math.max.apply(null, xs) + mx);
+    var y1 = Math.min(photo.imgH, Math.max.apply(null, ys) + my);
+    var cw = x1 - x0, ch = y1 - y0;
+    if (cw <= 0 || ch <= 0) { return; }
+    crop.style.paddingTop = (ch / cw * 100) + '%';
+    img.style.cssText = 'position:absolute;display:block;' +
+      'width:' + (photo.imgW / cw * 100) + '%;' +
+      'left:' + (-x0 / cw * 100) + '%;' +
+      'top:' + (-y0 / ch * 100) + '%;';
+  }
+  function renderPhotoPanel() {
+    var fs = photo.frames;
+    var i = photo.idx;
+    if (!fs || i == null) { $('photo-panel').hidden = true; return; }
+    $('photo-img').src = fs[i].url;
+    var ply = currentPly();
+    var rel = '';
+    if (ply >= 1) {
+      var d = fs[i].t - currentPlyTime();
+      rel = Math.abs(d) <= 4 ? (d >= 0 ? '・' + ply + '手目の直後' : '・' + ply + '手目の直前')
+        : (d > 0 ? '・' + ply + '手目の約' + Math.round(d) + '秒後'
+                 : '・' + ply + '手目の約' + Math.round(-d) + '秒前');
+    }
+    $('photo-caption').textContent = '実際の映像 ' + fmtTime(fs[i].t) + rel;
+    $('photo-prev').disabled = i <= 0;
+    $('photo-next').disabled = i >= fs.length - 1;
+    $('photo-panel').hidden = false;
+  }
+  function updatePhotoForPly() {
+    if (!photo.frames) { return; }
+    photo.idx = nearestFrameIdx(currentPlyTime());
+    renderPhotoPanel();
+  }
+  function initPhotoPanel() {
+    photo.frames = null; photo.points = null; photo.idx = null;
+    $('photo-panel').hidden = true;
+    loadFrames().then(function (resp) {
+      if (!resp || !resp.frames || !resp.frames.length) { return; }
+      photo.frames = resp.frames;
+      photo.points = Array.isArray(resp.points) ? resp.points : null;
+      updatePhotoForPly();
+    });
+  }
+
+  function inZoneLocal(side, d) { return side === 'sente' ? d <= 3 : d >= 7; }
+  function mustPromoteLocal(side, kind, d) {
+    if (kind === 'fu' || kind === 'ky') { return side === 'sente' ? d === 1 : d === 9; }
+    if (kind === 'ke') { return side === 'sente' ? d <= 2 : d >= 8; }
+    return false;
+  }
+
+  function clearSel() {
+    correction.from = null; correction.fromKind = null; correction.dropKind = null;
+    var sels = document.querySelectorAll('#board .sq.sel, .hands .hand-piece.sel');
+    for (var i = 0; i < sels.length; i++) { sels[i].classList.remove('sel'); }
+  }
+
+  function enterCorrection() {
+    if (!viewer.positions || viewer.idx === 0 || correction.busy) { return; }
+    correction.active = true;
+    correction.ply = viewer.idx;
+    clearSel();
+    var side = correctionSide();
+    renderBoard(viewer.positions[correction.ply - 1], null); // 訂正する手の直前局面
+    $('board').classList.add('correcting');
+    $(side === 'sente' ? 'hands-sente' : 'hands-gote').classList.add('tappable');
+    $('ply-label').textContent = correction.ply + '手目を訂正中';
+    $('correct-done').hidden = true;
+    $('correct-bar').hidden = false;
+    $('correct-bar').classList.remove('busy');
+    setViewerLocked(true); // 盤・持ち駒・キャンセル・映像コマ送り以外は封じる
+    updatePhotoForPly(); // 常設の映像パネルは訂正中も同じ手のコマを表示し続ける
+    setCorrectMsg(correction.ply + '手目（' + (side === 'sente' ? '▲先手' : '△後手') +
+      '）の正しい手を入力: 動かした駒（打った場合は持ち駒）→ 行き先 の順にタップしてください');
+  }
+
+  function exitCorrection() {
+    correction.active = false;
+    stopCorrectTimer();
+    removeBoardOverlay();
+    clearSel();
+    setViewerLocked(false);
+    $('board').classList.remove('correcting');
+    $('hands-sente').classList.remove('tappable');
+    $('hands-gote').classList.remove('tappable');
+    $('correct-bar').hidden = true;
+    $('correct-bar').classList.remove('busy');
+    $('btn-correct-cancel').disabled = false;
+  }
+
+  function selectFrom(s, d, token) {
+    clearSel();
+    correction.from = [s, d];
+    correction.fromKind = token.substr(1);
+    var el = document.querySelector('#board .sq[data-s="' + s + '"][data-d="' + d + '"]');
+    if (el) { el.classList.add('sel'); }
+    setCorrectMsg(KANJI_1[correction.fromKind] + '（' + s + d + '）を選択中。行き先のマスをタップしてください');
+  }
+
+  function onSquareTap(s, d) {
+    var side = correctionSide();
+    var pre = viewer.positions[correction.ply - 1];
+    var v = pre.ban[String(s) + String(d)];
+    var own = !!(v && v !== ' * ' && ((v.charAt(0) === 'v') === (side === 'gote')));
+
+    if (correction.from == null && correction.dropKind == null) {
+      if (own) { selectFrom(s, d, v); }
+      else {
+        setCorrectMsg('まず動かした駒（' + (side === 'sente' ? '▲先手' : '△後手') +
+          '側）か持ち駒をタップしてください');
+      }
+      return;
+    }
+    if (correction.from && correction.from[0] === s && correction.from[1] === d) {
+      clearSel();
+      setCorrectMsg('選択を解除しました。動かした駒か持ち駒をタップしてください');
+      return;
+    }
+    if (own) { selectFrom(s, d, v); return; } // 自駒タップは選び直し
+
+    if (correction.dropKind != null) { // 打ち
+      if (v && v !== ' * ') { setCorrectMsg('打つ先は空きマスを選んでください'); return; }
+      if (mustPromoteLocal(side, correction.dropKind, d)) { setCorrectMsg('そのマスには打てません'); return; }
+      submitCorrection({ from: null, to: [s, d], kind: correction.dropKind });
+      return;
+    }
+    // 盤上の駒の移動。成れる手だけ確認する(行き所のない手は強制成り)
+    var kind = correction.fromKind;
+    var promote = false;
+    if (PROMOTE[kind] && (inZoneLocal(side, d) || inZoneLocal(side, correction.from[1]))) {
+      promote = mustPromoteLocal(side, kind, d) || window.confirm('成りますか？（OK=成る／キャンセル=不成）');
+    }
+    submitCorrection({ from: correction.from, to: [s, d], kind: kind, promote: promote });
+  }
+
+  function onHandTap(el) {
+    var side = correctionSide();
+    if (el.getAttribute('data-side') !== side) {
+      setCorrectMsg('手番側（' + (side === 'sente' ? '▲先手' : '△後手') + '）の持ち駒を選んでください');
+      return;
+    }
+    clearSel();
+    correction.dropKind = el.getAttribute('data-kind');
+    el.classList.add('sel');
+    setCorrectMsg(KANJI_1[correction.dropKind] + 'を打ちます。打つマスをタップしてください');
+  }
+
+  function submitCorrection(m) {
+    var ply = correction.ply;
+    var t = viewer.plies[ply - 1].frameIdx;
+    var pin = { t: t, from: m.from, to: m.to, kind: m.kind, ply: ply };
+    if (m.promote !== undefined) { pin.promote = m.promote; }
+    correction.busy = true;
+    $('correct-bar').classList.add('busy');
+    // 再解中はキャンセルも無効(サーバー側は完了してしまうため、途中中断は状態の食い違いを生む)
+    $('btn-correct-cancel').disabled = true;
+    showBoardOverlay('再解析中…');
+    startCorrectTimer();
+    var oldPlies = viewer.plies.slice(); // 完了時に「どこが変わったか」を出すための控え
+    var prevCorrectedAt = viewer.correctedAt || null;
+    fetch(API_BASE + '/jobs/' + encodeURIComponent(state.jobId) + '/correct', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pin: pin })
+    }).then(function (res) {
+      if (res.status === 422) { // ピン不成立(指せない手など)。サーバー側は何も変えていない
+        return res.json().then(function (j) {
+          var e = new Error((j && j.message) || 'この訂正は反映できませんでした');
+          e.unapplied = true;
+          throw e;
+        });
+      }
+      if (!res.ok) { throw new Error('HTTP ' + res.status); }
+      return res.json();
+    }).then(function (resp) {
+      applyCorrection(resp.result, ply, oldPlies, !!resp.evalsRecomputing);
+    }).catch(function (err) {
+      if (err && err.unapplied) {
+        stopCorrectTimer();
+        correction.busy = false;
+        $('correct-bar').classList.remove('busy');
+        $('btn-correct-cancel').disabled = false;
+        removeBoardOverlay();
+        clearSel();
+        setCorrectMsg('⚠ ' + err.message + '。手をよくご確認のうえ、もう一度入力してください');
+        return;
+      }
+      // タイムアウト等でもサーバー側では完了している可能性があるため、結果をポーリングで拾う
+      // (経過表示のタイマーは動かしたまま。30秒超の文言に自動で切り替わる)
+      console.warn('correct request failed; falling back to polling', err);
+      pollCorrected(prevCorrectedAt, ply, oldPlies);
+    });
+  }
+
+  // 訂正リクエストの応答が取れなかったときの保険。kif.json の correctedAt の
+  // 変化を最大60秒待ち、変わっていれば成功として取り込む。
+  function pollCorrected(prevCorrectedAt, ply, oldPlies) {
+    var tries = 0;
+    function tick() {
+      if (++tries > 20) {
+        stopCorrectTimer();
+        correction.busy = false;
+        $('correct-bar').classList.remove('busy');
+        $('btn-correct-cancel').disabled = false;
+        removeBoardOverlay();
+        setCorrectMsg('⚠ 通信に失敗しました。電波状況をご確認のうえ、もう一度お試しください');
+        return;
+      }
+      setTimeout(function () {
+        fetch(API_BASE + '/jobs/' + encodeURIComponent(state.jobId), { cache: 'no-store' })
+          .then(function (res) { return res.ok ? res.json() : null; })
+          .then(function (job) {
+            var r = job && job.result;
+            // フォールバック経路では evalsRecomputing が分からないため控えめに false
+            // (旧バックエンドで「計算中」を出しっぱなしにしない)
+            if (r && r.correctedAt && r.correctedAt !== prevCorrectedAt) { applyCorrection(r, ply, oldPlies, false); }
+            else { tick(); }
+          })
+          .catch(tick);
+      }, 3000);
+    }
+    tick();
+  }
+
+  // ---- 訂正後の形勢グラフ後追い ----
+  // 訂正が成功するとバックエンドが evaluate を非同期で叩き直す(aws PR#38)。
+  // correctedAt が一致する evals が kif.json に付くまでポーリングして差し込む。
+  // 途中で別の訂正が入ったら(correctedAt不一致)このポーリングは役目を終える
+  // (新しい訂正が自分のポーリングを張り直す)。
+  var evalPoll = { timer: null, expected: null };
+  function stopEvalPoll() {
+    if (evalPoll.timer) { clearInterval(evalPoll.timer); evalPoll.timer = null; }
+  }
+  function startEvalPoll(expectedCorrectedAt) {
+    stopEvalPoll();
+    evalPoll.expected = expectedCorrectedAt || null;
+    var tries = 0;
+    evalPoll.timer = setInterval(function () {
+      // 最大12分で諦める。評価はsunfishの既知問題(特定局面で無応答→タイムアウト待ち)で
+      // 数分かかることがある(実測: 83手のnull多発対局で5分超)
+      if (++tries > 120) { stopEvalPoll(); $('eval-wrap').hidden = true; return; }
+      fetch(API_BASE + '/jobs/' + encodeURIComponent(state.jobId), { cache: 'no-store' })
+        .then(function (res) { return res.ok ? res.json() : null; })
+        .then(function (job) {
+          var r = job && job.result;
+          if (!r) { return; }
+          if ((r.correctedAt || null) !== evalPoll.expected) { stopEvalPoll(); return; }
+          if (!Array.isArray(r.evals) || !r.evals.length) { return; } // まだ計算中
+          if (correction.active || correction.busy) { return; } // 訂正中は反映を保留
+          stopEvalPoll();
+          applyEvals({ status: 'SUCCEEDED', result: r });
+        })
+        .catch(function () {});
+    }, 6000);
+  }
+
+  // 旧棋譜との差分から「どこが変わったか」を手番号のリストで返す(1始まり)
+  function changedPlies(oldPlies, newPlies) {
+    var out = [];
+    var n = Math.max(oldPlies.length, newPlies.length);
+    for (var i = 0; i < n; i++) {
+      var a = oldPlies[i], b = newPlies[i];
+      if (!a || !b || !movesEqual(a.move, b.move)) { out.push(i + 1); }
+    }
+    return out;
+  }
+
+  function applyCorrection(result, ply, oldPlies, evalsRecomputing) {
+    stopCorrectTimer();
+    correction.busy = false;
+    exitCorrection();
+    // 訂正で手数が変わることがある(手が復活する等)。ビューワーごと差し替える。
+    // evals(形勢グラフ)は訂正直後は未計算(initViewerが隠す)。バックエンドが
+    // 再計算中なら「計算中」を出して後追いポーリングで差し込む。
+    showResult({ status: 'SUCCEEDED', result: result });
+    viewer.correctedAt = result.correctedAt || null;
+    showPosition(Math.min(ply, viewer.positions.length - 1));
+    var evalNote;
+    if (evalsRecomputing) {
+      setEvalPending();
+      startEvalPoll(result.correctedAt || null);
+      evalNote = '（形勢グラフは再計算中です。数分かかることがありますが自動で更新されます）';
+    } else {
+      evalNote = '（形勢グラフは訂正後の再計算に未対応です）';
+    }
+
+    // どこが変わったかを明示する。訂正の価値(連鎖で以降も直る)はここで初めて目に見える
+    var changed = oldPlies ? changedPlies(oldPlies, viewer.plies) : [];
+    var others = changed.filter(function (p) { return p !== ply; });
+    var msg;
+    if (changed.length === 0) {
+      msg = '✔ ' + ply + '手目の訂正を確認しました（棋譜に変更はありませんでした・全' +
+        viewer.plies.length + '手）。';
+    } else if (others.length === 0) {
+      msg = '✔ ' + ply + '手目を訂正しました（他の手は変わっていません・全' +
+        viewer.plies.length + '手）。';
+    } else {
+      msg = '✔ ' + ply + '手目を訂正 → ほかに' + others.length + '手が変わりました（' +
+        Math.min.apply(null, others) + '〜' + Math.max.apply(null, others) + '手目・全' +
+        viewer.plies.length + '手）。黄色の手が変わった箇所です。';
+    }
+    var done = $('correct-done');
+    done.textContent = msg + 'まだ違う手があれば、同じように訂正できます。' + evalNote;
+    done.hidden = false;
+
+    // 変わった手を一覧上でハイライト(読む時間を考えて30秒で消す。
+    // 次の訂正やビューワー再構築でも自然に消える)
+    var items = document.querySelectorAll('#move-list li');
+    changed.forEach(function (p) {
+      if (items[p - 1]) { items[p - 1].classList.add('changed'); }
+    });
+    if (changed.length) {
+      setTimeout(function () {
+        var lis = document.querySelectorAll('#move-list li.changed');
+        for (var k = 0; k < lis.length; k++) { lis[k].classList.remove('changed'); }
+      }, 30000);
+    }
   }
 
   // ---- 結果表示 ----
@@ -693,6 +1279,14 @@
       d.textContent = '⚠️ ' + w;
       box.appendChild(d);
     });
+    // 要確認手は訂正の入口: v2なら直し方をここで案内する
+    if (warns.length > 0 && result.pipeline === 'v2') {
+      var hint = document.createElement('div');
+      hint.style.cssText = 'margin-top:6px;font-size:12px;color:#8a6d3b;';
+      hint.textContent = '⚠の手は読み取りに自信がありません。下の指し手一覧でオレンジ色の手をタップして局面を確かめ、' +
+        '間違っていたら「この手が違う（訂正する）」から正しい手を入力すると、以降の手も自動で直ります。';
+      box.appendChild(hint);
+    }
     box.hidden = warns.length === 0;
     // 新backendで実行継続中(RUNNING)かつ evals 未着なら「計算中」を出す。
     // 旧backendは SUCCEEDED 時に evals 込みで来るため pending にはならない。
@@ -735,6 +1329,10 @@
 
   function maybeCompress(file) {
     if (file.size <= COMPRESS_THRESHOLD_BYTES) { return Promise.resolve(file); }
+    if (!compressEnabled()) {
+      compressNote('圧縮をオフにしているため、そのままアップロードします');
+      return Promise.resolve(file);
+    }
     if (!(window.VideoCompress && window.VideoCompress.isSupported())) {
       var miss = compressSupportDetail();
       compressNote('この端末では動画圧縮が使えないため、そのままアップロードします'
@@ -776,9 +1374,24 @@
   // ブラウザ圧縮が使える環境では、圧縮後に2GBを大きく下回るため
   // 元ファイルの上限を緩和する(アクションカメラの長時間録画は平気で2GBを超える)。
   var MAX_RAW_BYTES_WITH_COMPRESS = 20 * 1000 * 1000 * 1000;
+  // 圧縮トグル: 記憶された選択を反映し、変更を保存する
+  try { if (localStorage.getItem(COMPRESS_OFF_KEY) === '1') { $('compress-toggle').checked = false; } } catch (e) {}
+  $('compress-toggle').addEventListener('change', function () {
+    try {
+      if (compressEnabled()) { localStorage.removeItem(COMPRESS_OFF_KEY); }
+      else { localStorage.setItem(COMPRESS_OFF_KEY, '1'); }
+    } catch (e) {}
+    // 圧縮オフでは2GB超を受理できないため、該当ファイルは選び直してもらう
+    if (state.file && !compressEnabled() && state.file.size > MAX_UPLOAD_BYTES) {
+      state.file = null;
+      $('file-input').value = '';
+      $('btn-start').disabled = true;
+      $('file-info').textContent = '圧縮オフでは2GBまでの動画のみアップロードできます。ファイルを選び直してください。';
+    }
+  });
   $('file-input').addEventListener('change', function (e) {
     var f = e.target.files[0] || null;
-    var canCompress = !!(window.VideoCompress && window.VideoCompress.isSupported());
+    var canCompress = compressEnabled() && !!(window.VideoCompress && window.VideoCompress.isSupported());
     var limit = canCompress ? MAX_RAW_BYTES_WITH_COMPRESS : MAX_UPLOAD_BYTES;
     if (f && f.size > limit) {
       state.file = null;
@@ -831,6 +1444,37 @@
   $('btn-last').addEventListener('click', function () {
     if (viewer.positions) { showPosition(viewer.positions.length - 1); }
   });
+  // 訂正モードの操作
+  $('btn-correct').addEventListener('click', enterCorrection);
+  $('btn-correct-cancel').addEventListener('click', function () {
+    if (correction.busy) { return; }
+    var p = correction.ply;
+    exitCorrection();
+    showPosition(p);
+  });
+  $('board').addEventListener('click', function (ev) {
+    if (!correction.active || correction.busy) { return; }
+    var t = ev.target;
+    if (!t || !t.getAttribute || t.getAttribute('data-s') == null) { return; }
+    onSquareTap(Number(t.getAttribute('data-s')), Number(t.getAttribute('data-d')));
+  });
+  function handTapHandler(ev) {
+    if (!correction.active || correction.busy) { return; }
+    var t = ev.target;
+    if (!t || !t.classList || !t.classList.contains('hand-piece')) { return; }
+    onHandTap(t);
+  }
+  $('hands-sente').addEventListener('click', handTapHandler);
+  $('hands-gote').addEventListener('click', handTapHandler);
+  // 実映像パネルのコマ送り(訂正中もロック対象外)と、読み込み時の盤領域クロップ適用
+  $('photo-prev').addEventListener('click', function () {
+    if (photo.frames && photo.idx > 0) { photo.idx--; renderPhotoPanel(); }
+  });
+  $('photo-next').addEventListener('click', function () {
+    if (photo.frames && photo.idx < photo.frames.length - 1) { photo.idx++; renderPhotoPanel(); }
+  });
+  $('photo-img').addEventListener('load', applyPhotoCrop);
+
   $('btn-sfen').addEventListener('click', function () {
     if (!viewer.positions) { return; }
     var sfen = toSfen(viewer.positions[viewer.idx], viewer.idx + 1);


### PR DESCRIPTION
## ⚠️ マージ＝即本番(β)。オーナー確認必須
αレーンで実地検証済みの機能一式を video.html(β) へ昇格します。**マージするとβ利用者全員に訂正機能が公開されます。**

## 載るもの(すべてαで本番検証済み)
- **訂正UI**: 間違っている最初の手まで進めて「この手が違う（訂正する）」→ 直前局面で2タップ → ピン再解で以降の手も自動修正(83手実対局で12秒前後)
- **待ち体験**: 経過秒+動的目安+点滅ドット、完了時「N手目を訂正 → ほかにM手が変わりました」+黄色ハイライト
- **実映像パネル(常設)**: 手を進めるたびに実映像の該当コマへ追従、盤領域クロップ、◀▶コマ送り
- **操作ロック+盤オーバーレイ**: 訂正中は盤タップ/キャンセル/コマ送り以外を封じ、再解析中は白半透明+スピナー
- **形勢グラフ再計算の後追い**(aws PR#38/#39デプロイ済み): 訂正後「再計算中(数分)」→自動更新
- **PC2カラム**(900px以上): 盤と映像を横並び。SPは従来の縦積み(非退行をヘッドレスで確認)
- **圧縮オン/オフ**(既定オン・記憶あり) — #36 を包含するため、本PRマージ後 #36 はクローズ

## 生成方法と検証
alphaブランチ最新の video-alpha.html から機械変換(タイトル/OGP/バッジ復元・α案内カード削除)。α痕跡0をgrepで確認、インラインJS構文チェックPASS、ヘッドレスChromeでPC2カラム表示・⚠手表示・訂正ボタンまで確認。

## 関連
- #38(αレーンmaster側整理)と順不同でマージ可(触るファイルが異なる)
- αページは今後も実験場として存続(次はデザイン磨きをαで回してからβへ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)